### PR TITLE
Bump dependencies (fix meal command)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "bilkent-scraper": "^1.0.0",
+        "bilkent-scraper": "^1.0.1",
         "dayjs": "^1.10.8",
         "discord.js": "^13.6.0",
         "node-fetch": "^2.6.7",
@@ -649,9 +649,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/bilkent-scraper": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bilkent-scraper/-/bilkent-scraper-1.0.0.tgz",
-      "integrity": "sha512-pI9LdclQ0b/xYSJjplLbbkS0Ys7bZLGQuNkejn3GH8fZKj8qg94Z/EIfl+qLOoZ87+LgnwJgPi1wlrweleZgxA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bilkent-scraper/-/bilkent-scraper-1.0.1.tgz",
+      "integrity": "sha512-84eAXGCf5mYf5y1wntENSIxXrmnGm9ZQRH8qGx5To9RlEOhf0K2qK7JltTidGyWe+OO7moDCvmIr4N5YKFCN0w==",
       "dependencies": {
         "dayjs": "^1.11.0",
         "jsdom": "^19.0.0",
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -3864,9 +3864,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "bilkent-scraper": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bilkent-scraper/-/bilkent-scraper-1.0.0.tgz",
-      "integrity": "sha512-pI9LdclQ0b/xYSJjplLbbkS0Ys7bZLGQuNkejn3GH8fZKj8qg94Z/EIfl+qLOoZ87+LgnwJgPi1wlrweleZgxA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bilkent-scraper/-/bilkent-scraper-1.0.1.tgz",
+      "integrity": "sha512-84eAXGCf5mYf5y1wntENSIxXrmnGm9ZQRH8qGx5To9RlEOhf0K2qK7JltTidGyWe+OO7moDCvmIr4N5YKFCN0w==",
       "requires": {
         "dayjs": "^1.11.0",
         "jsdom": "^19.0.0",
@@ -5139,9 +5139,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Ved",
   "license": "MIT",
   "dependencies": {
-    "bilkent-scraper": "^1.0.0",
+    "bilkent-scraper": "^1.0.1",
     "dayjs": "^1.10.8",
     "discord.js": "^13.6.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
- Bump `bilkent-scraper` to v1.0.1
- Bump `minimist` because apparently it had a high risk security warning?
